### PR TITLE
Redirect to app at subdomain.ospc.org

### DIFF
--- a/404.html
+++ b/404.html
@@ -33,7 +33,7 @@ layout: default
   // If the user is trying to access an archived run, then they may have a link
   // to wwww.ospc.org/{extension}/{runnumber}/. If the extension matches any
   // of the below extensions, then they will be redirected to
-  // apps_domain/{extension}/query
+  // apps_domain/{extension}/query.
   var extentions = [
     "taxbrain",
     "ccc",
@@ -44,10 +44,11 @@ layout: default
     "dynamic/macro_results",
   ];
 
-  // check if the url starts with https://www.ospc.org/{ext}
-  // redirect if there is a match.
+  // Check if the url starts with https://www.ospc.org/{ext}
+  // Redirect if there is a match.
   if (extentions.some(ext => url.startsWith(cur_domain + ext))) {
-    // grap the part of the url that comes after cur_domain
+    // Grab the part of the url that comes after cur_domain.
+    // This part would contains the run number and/or GET parameters.
     var spl = url.split(cur_domain);
     var archived_url = apps_domain + spl[1];
     window.location.replace(archived_url);

--- a/404.html
+++ b/404.html
@@ -22,3 +22,32 @@ layout: default
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
 </div>
+
+<script>
+  var url = location.href;
+  var apps_domain = "https://ospc-apps.herokuapp.com/";
+  var cur_domain = "https" + location.hostname;
+
+  // If the user is trying to access an archived run, then they may have a link
+  // to wwww.ospc.org/{extension}/{runnumber}/. If the extension matches any
+  // of the below extensions, then they will be redirected to
+  // apps_domain/{extension}/query
+  var extentions = [
+    "taxbrain",
+    "ccc",
+    "dynamic",
+    "dynamic/behavioral",
+    "dynamic/behavior_results",
+    "dynamic/macro",
+    "dynamic/macro_results",
+  ];
+
+  // check if the url starts with https://www.ospc.org/{ext}
+  // redirect if there is a match.
+  if (extentions.some(ext => url.startsWith(cur_domain + ext))) {
+    var spl = url.split(cur_domain);
+    var archived_url = apps_domain + spl[1];
+    // redirect to the archived run at archived_url.
+    window.location.replace(archived_url);
+  }
+</script>

--- a/404.html
+++ b/404.html
@@ -25,7 +25,9 @@ layout: default
 
 <script>
   var url = location.href;
+  // Needs to be changed to the ospc.org subdomain once that is setup.
   var apps_domain = "https://ospc-apps.herokuapp.com/";
+  // cur_domain will be https://www.ospc.org in production.
   var cur_domain = "https" + location.hostname;
 
   // If the user is trying to access an archived run, then they may have a link
@@ -45,9 +47,9 @@ layout: default
   // check if the url starts with https://www.ospc.org/{ext}
   // redirect if there is a match.
   if (extentions.some(ext => url.startsWith(cur_domain + ext))) {
+    // grap the part of the url that comes after cur_domain
     var spl = url.split(cur_domain);
     var archived_url = apps_domain + spl[1];
-    // redirect to the archived run at archived_url.
     window.location.replace(archived_url);
   }
 </script>

--- a/404.html
+++ b/404.html
@@ -48,7 +48,7 @@ layout: default
   // Redirect if there is a match.
   if (extentions.some(ext => url.startsWith(cur_domain + ext))) {
     // Grab the part of the url that comes after cur_domain.
-    // This part would contains the run number and/or GET parameters.
+    // This part would contain the run number and/or GET parameters.
     var spl = url.split(cur_domain);
     var archived_url = apps_domain + spl[1];
     window.location.replace(archived_url);

--- a/404.html
+++ b/404.html
@@ -25,8 +25,7 @@ layout: default
 
 <script>
   var url = location.href;
-  // Needs to be changed to the ospc.org subdomain once that is setup.
-  var apps_domain = "https://ospc-apps.herokuapp.com/";
+  var apps_domain = "https://apps.ospc.org/";
   // cur_domain will be https://www.ospc.org in production.
   var cur_domain = "https" + location.hostname;
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,4 +150,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/ccc.md
+++ b/ccc.md
@@ -8,8 +8,8 @@ exclude: true
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting…</title>
-  <link rel="canonical" href="http://ospc.org/ccc/">
-  <meta http-equiv="refresh" content="0; url=http://ospc.org/ccc/">
+  <link rel="canonical" href="http://apps.ospc.org/ccc/">
+  <meta http-equiv="refresh" content="0; url=http://apps.ospc.org/ccc/">
   <h1>Redirecting…</h1>
-  <a href="http://ospc.org/ccc/">Click here if you are not redirected.</a>
+  <a href="http://apps.ospc.org/ccc/">Click here if you are not redirected.</a>
 </html>

--- a/ccc.md
+++ b/ccc.md
@@ -1,0 +1,15 @@
+---
+permalink: /ccc/
+layout: page
+exclude: true
+---
+
+
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="http://ospc.org/ccc/">
+  <meta http-equiv="refresh" content="0; url=http://ospc.org/ccc/">
+  <h1>Redirecting…</h1>
+  <a href="http://ospc.org/ccc/">Click here if you are not redirected.</a>
+</html>

--- a/taxbrain.md
+++ b/taxbrain.md
@@ -1,0 +1,15 @@
+---
+permalink: /taxbrain/
+layout: page
+exclude: true
+---
+
+
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+  <link rel="canonical" href="http://ospc.org/taxbrain/">
+  <meta http-equiv="refresh" content="0; url=http://ospc.org/taxbrain/">
+  <h1>Redirecting…</h1>
+  <a href="http://ospc.org/taxbrain/">Click here if you are not redirected.</a>
+</html>

--- a/taxbrain.md
+++ b/taxbrain.md
@@ -8,8 +8,8 @@ exclude: true
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting…</title>
-  <link rel="canonical" href="http://ospc.org/taxbrain/">
-  <meta http-equiv="refresh" content="0; url=http://ospc.org/taxbrain/">
+  <link rel="canonical" href="http://apps.ospc.org/taxbrain/">
+  <meta http-equiv="refresh" content="0; url=http://apps.ospc.org/taxbrain/">
   <h1>Redirecting…</h1>
-  <a href="http://ospc.org/taxbrain/">Click here if you are not redirected.</a>
+  <a href="http://apps.ospc.org/taxbrain/">Click here if you are not redirected.</a>
 </html>


### PR DESCRIPTION
This PR redirects users who are looking for the TaxBrain or CCC webapp to the appropriate app. These redirects are needed because we want to transfer the ospc.org domain name to the github pages site and continue serving TaxBrain and CCC on the dynamic heroku app. Our approach is to redirect users using the [`meta`][1] tag if they are searching for the TaxBrain or CCC landing page. That is, they have followed or typed one of the following links: https://www.ospc.org/taxbrain or https://www.ospc.org/ccc. The redirecting is done with the tag: `<meta http-equiv="refresh" content="0; url=http://ospc.org/taxbrain/">`. 

If the user is searching for an archived run, then their URL will look like https://www.ospc.org/taxbrain/runnumber/ or https://www.ospc.org/ccc/runnumber/. This results in a 404 error on the GitHub pages site. To use the same redirect logic that we have above (using the meta tag), then we would need an HTML page corresponding to every single archived run. This is not feasible, especially since new runs are archived every day. This issue is resolved by examining the link that was used to generate the 404 page through the [`window.location.href`][2] attribute. For example, if the user tries to go to https://www.ospc.org/taxbrain/32000/, then the `window.location.href` is just https://www.ospc.org/taxbrain/32000/. Next, we need to determine if this is a true 404 error or a user looking for an archived run. So, we compare the link against the dynamic app URL (which will be a subdomain of ospc.org) and a list of allowed extentions:

```javascript
  var extentions = [
    "taxbrain",
    "ccc",
    "dynamic",
    "dynamic/behavioral",
    "dynamic/behavior_results",
    "dynamic/macro",
    "dynamic/macro_results",
  ];
```

If the link that the user is looking for starts with the https://www.ospc.org/{extension}/, then the user is redirected to https://somesubdomain.ospc.org/{extension}/{runnumber}/. If there are no matches, then the normal 404 page is shown.

[1]: https://stackoverflow.com/questions/18955195/can-i-redirect-a-local-static-html-page-to-an-online-resource
[2]: https://www.w3schools.com/js/js_window_location.asp