### PR TITLE
Add .jekyll-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .sass-cache
 .jekyll-metadata
 .DS_Store
+.jekyll-cache/


### PR DESCRIPTION
This PR adds `.jekyll-cache` to the `gitignore`.